### PR TITLE
fix: replace ::set-output by $GITHUB_OUTPUT

### DIFF
--- a/src/parse_input_extra_args.Tests.ps1
+++ b/src/parse_input_extra_args.Tests.ps1
@@ -9,7 +9,7 @@ Describe "parse_input_extra_args" {
         It "it should return envNames" {
             $envNames = '@NAME1, NAME2'
             .\parse_input_extra_args.ps1 -envNames $envNames | Should -Be `
-                            "::set-output name=extra_args::  --env NAME1 --env  NAME2 "
+                            "`"extra_args=  --env NAME1 --env  NAME2 `" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -17,7 +17,7 @@ Describe "parse_input_extra_args" {
         It "it should return entrypoint" {
             $entryPoint = '@pwsh.exe'
             .\parse_input_extra_args.ps1 -entryPoint $entryPoint | Should -Be `
-                            "::set-output name=extra_args::   --entrypoint pwsh.exe"
+                            "`"extra_args=   --entrypoint pwsh.exe`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -25,7 +25,7 @@ Describe "parse_input_extra_args" {
         It "it should return extra args" {
             $extraArgs = '@--test 123456'
             .\parse_input_extra_args.ps1 -extraArgs $extraArgs | Should -Be `
-                            "::set-output name=extra_args::--test 123456  "
+                            "`"extra_args=--test 123456  `" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -34,7 +34,7 @@ Describe "parse_input_extra_args" {
             $entryPoint = '@pwsh.exe'
             $extraArgs = '@--test 123456'
             .\parse_input_extra_args.ps1 -entryPoint $entryPoint -extraArgs $extraArgs | Should -Be `
-                            "::set-output name=extra_args::--test 123456   --entrypoint pwsh.exe"
+                            "`"extra_args=--test 123456   --entrypoint pwsh.exe`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -43,7 +43,7 @@ Describe "parse_input_extra_args" {
             $entryPoint = '@pwsh.exe'
             $envNames = '@NAME1,NAME2'
             .\parse_input_extra_args.ps1 -entryPoint $entryPoint -envNames $envNames | Should -Be `
-                            "::set-output name=extra_args::  --env NAME1 --env NAME2  --entrypoint pwsh.exe"
+                            "`"extra_args=  --env NAME1 --env NAME2  --entrypoint pwsh.exe`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -53,7 +53,7 @@ Describe "parse_input_extra_args" {
             $envNames = '@NAME1,NAME2'
             $extraArgs = '@--test 123456'
             .\parse_input_extra_args.ps1 -entryPoint $entryPoint -envNames $envNames -extraArgs $extraArgs | Should -Be `
-                            "::set-output name=extra_args::--test 123456  --env NAME1 --env NAME2  --entrypoint pwsh.exe"
+                            "`"extra_args=--test 123456  --env NAME1 --env NAME2  --entrypoint pwsh.exe`" >> `$GITHUB_OUTPUT"
         }
     }
 }

--- a/src/parse_input_paths.Tests.ps1
+++ b/src/parse_input_paths.Tests.ps1
@@ -3,9 +3,9 @@ Describe "parse_input_paths" {
         It "it should return gitworkspace" {
             $githubWorkSpace = '@github_work_space'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace | Should -Be `
-                            "::set-output name=workspace_path::github_work_space", `
-                            "::set-output name=mapping_path::github_work_space", `
-                            "::set-output name=work_path::github_work_space"
+                            "`"workspace_path=github_work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=github_work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=github_work_space`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -14,9 +14,9 @@ Describe "parse_input_paths" {
             $githubWorkSpace = '@github_work_space'
             $workSpace = '@work_space'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace -workspacePath $workSpace  | Should -Be `
-                            "::set-output name=workspace_path::work_space", `
-                            "::set-output name=mapping_path::work_space", `
-                            "::set-output name=work_path::work_space"
+                            "`"workspace_path=work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=work_space`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -26,9 +26,9 @@ Describe "parse_input_paths" {
             $workSpace = '@work_space'
             $mapping = '@mapping'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace -workspacePath $workSpace -mappingPath $mapping  | Should -Be `
-                            "::set-output name=workspace_path::work_space", `
-                            "::set-output name=mapping_path::mapping", `
-                            "::set-output name=work_path::mapping"
+                            "`"workspace_path=work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=mapping`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=mapping`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -39,9 +39,9 @@ Describe "parse_input_paths" {
             $mapping = '@mapping'
             $work = '@work'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace -workspacePath $workSpace -mappingPath $mapping -workPath $work | Should -Be `
-                            "::set-output name=workspace_path::work_space", `
-                            "::set-output name=mapping_path::mapping", `
-                            "::set-output name=work_path::work"
+                            "`"workspace_path=work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=mapping`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=work`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -51,9 +51,9 @@ Describe "parse_input_paths" {
             $workSpace = '@work_space'
             $work = '@work'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace -workspacePath $workSpace -workPath $work | Should -Be `
-                            "::set-output name=workspace_path::work_space", `
-                            "::set-output name=mapping_path::work_space", `
-                            "::set-output name=work_path::work"
+                            "`"workspace_path=work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=work`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -63,9 +63,9 @@ Describe "parse_input_paths" {
             $mapping = '@mapping'
             $work = '@work'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace -mappingPath $mapping -workPath $work | Should -Be `
-                            "::set-output name=workspace_path::github_work_space", `
-                            "::set-output name=mapping_path::mapping", `
-                            "::set-output name=work_path::work"
+                            "`"workspace_path=github_work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=mapping`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=work`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -74,9 +74,9 @@ Describe "parse_input_paths" {
             $githubWorkSpace = '@github_work_space'
             $mapping = '@mapping'
             .\parse_input_paths.ps1 -githubWorkSpace $githubWorkSpace -mappingPath $mapping | Should -Be `
-                            "::set-output name=workspace_path::github_work_space", `
-                            "::set-output name=mapping_path::mapping", `
-                            "::set-output name=work_path::mapping"
+                            "`"workspace_path=github_work_space`" >> `$GITHUB_OUTPUT", `
+                            "`"mapping_path=mapping`" >> `$GITHUB_OUTPUT", `
+                            "`"work_path=mapping`" >> `$GITHUB_OUTPUT"
         }
     }
 }

--- a/src/set_output_variable.Tests.ps1
+++ b/src/set_output_variable.Tests.ps1
@@ -18,7 +18,7 @@ Describe "set_output_variable" {
         It "it should return output" {
             $name = '@theName'
             $val = '@value'
-            .\set_output_variable.ps1 -name $name -val $val | Should -Be "::set-output name=theName::value"
+            .\set_output_variable.ps1 -name $name -val $val | Should -Be "`"theName=value`" >> `$GITHUB_OUTPUT"
         }
     }
 
@@ -26,8 +26,7 @@ Describe "set_output_variable" {
         It "it should return output" {
             $name = 'theName'
             $val = 'value'
-            .\set_output_variable.ps1 -name $name -val $val | Should -Be "::set-output name=theName::value"
+            .\set_output_variable.ps1 -name $name -val $val | Should -Be "`"theName=value`" >> `$GITHUB_OUTPUT"
         }
     }
-
 }

--- a/src/set_output_variable.ps1
+++ b/src/set_output_variable.ps1
@@ -13,5 +13,5 @@ $trimmed_val  = & $trimArg -arg $val;
 
 if ( ${trimmed_val}.Trim(' ') -ne "" )
 {
-    Write-Output "::set-output name=$trimmed_name::$trimmed_val";
+    Write-Output "`"$trimmed_name=$trimmed_val`" >> `$GITHUB_OUTPUT";
 }


### PR DESCRIPTION
As per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ the usage of set-output has been deprecated and results in a warning when using this action.

This PR replaces the usage of ::set-output with $GITHUB_OUTPUT.