### PR TITLE
feat: add default GitHub environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           run: >-
             echo "Hello world";
             exit %ERRORLEVEL%;
+
       - name: Test_Environment
         uses: ./
         with:
@@ -62,6 +63,15 @@ jobs:
           env_names: TEST1, TEST2, TEST3
           run: >-
             c:\map\test\run_test.ps1 -testPath "c:\map\test\environment.Tests.ps1";
+
+      - name: Test_Default_Environment
+        uses: ./
+        with:
+          image: ${{ matrix.docker_container }}
+          entrypoint: powershell.exe
+          mapping_path: 'c:\map'
+          run: >-
+            c:\map\test\run_test.ps1 -testPath "c:\map\test\default_environment.Tests.ps1";
 
       - name: Test_WorkPath
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     name: Validate
-    container: mcr.microsoft.com/powershell:latest
+    container: mcr.microsoft.com/powershell:7.5-ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
              Install-Module -Name Pester -Force -SkipPublisherCheck;
              Update-Module -Name Pester -Force;
              Install-Module -Name PSScriptAnalyzer -Force;
+             Import-Module PSScriptAnalyzer -ErrorAction Stop
       - name: Linter src
         shell: pwsh
         run: >-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Action for running commands in a windows docker
+# Action for running commands in a windows docker container
 
 ## State
 
@@ -29,8 +29,14 @@ Very simple hello world example:
             ./run-test-script.ps1;
 ```
 
-On default, the github workspace directory is mapped to the docker volume path
-and work path. 
+## Default environment
+
+This action tries to stay close to GitHub's Action environment, and
+as such all GitHub defined [default environment variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) are passed
+to the container by default.
+
+By default, the github workspace directory is mapped to the docker volume path
+and work path.
 
 <!-- action-docs-inputs -->
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -65,14 +65,15 @@ runs:
     - name: check
       if: runner.os != 'Windows'
       run: |
-        echo "::error file=run-windows-docker-container-action/action.yml,line=52,col=1,endColumn=1::This action can only run on windows";
+        echo "::error file=run-windows-docker-container-action/action.yml,line=68,col=1,endColumn=1::This action can only run on windows";
         exit -1
       shell: bash
     - name: settings
       id: settings
       run: >-
-          ${{github.action_path}}/src/parse_input_paths.ps1 -githubWorkSpace "${{ github.workspace }}" -workspacePath "@${{ inputs.workspace_path }}" -mappingPath "@${{ inputs.mapping_path }}" -workPath "@${{ inputs.work_path }}";
-          ${{github.action_path}}/src/parse_input_extra_args.ps1 -envNames "@${{ inputs.env_names }}" -entryPoint "@${{ inputs.entrypoint }}" -extraArgs "@${{ inputs.extra_args }}";
+          ${{ github.action_path }}/src/parse_input_paths.ps1 -githubWorkSpace "${{ github.workspace }}" -workspacePath "@${{ inputs.workspace_path }}" -mappingPath "@${{ inputs.mapping_path }}" -workPath "@${{ inputs.work_path }}";
+          ${{ github.action_path }}/src/parse_input_extra_args.ps1 -envNames "@${{ inputs.env_names }}" -entryPoint "@${{ inputs.entrypoint }}" -extraArgs "@${{ inputs.extra_args }}";
+          ${{ github.action_path }}/src/assign_default_environment_variables.ps1;
       shell: powershell
     - name: docker_login
       id: docker_login
@@ -92,7 +93,9 @@ runs:
       shell: powershell
     - name: Run
       run: >-
-        docker run ${{ steps.settings.outputs.extra_args }}
+        docker run
+        ${{ steps.settings.outputs.default_environment_variables }}
+        ${{ steps.settings.outputs.extra_args }}
         --rm 
         --memory=${{ inputs.memory }}
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}

--- a/src/assign_default_environment_variables.Tests.ps1
+++ b/src/assign_default_environment_variables.Tests.ps1
@@ -33,7 +33,7 @@ Describe "assign_default_environment_variables" {
             }
 
             # Assert: Verify the output variable is set correctly
-            $result | Should -Match "default_environment_variables=@"
+            $result | Should -Match "default_environment_variables="
         }
     }
 }

--- a/src/assign_default_environment_variables.Tests.ps1
+++ b/src/assign_default_environment_variables.Tests.ps1
@@ -1,0 +1,39 @@
+
+Describe "assign_default_environment_variables" {
+    BeforeEach{
+        function toGitHub () {
+            param(
+                $output_name,
+                $output_value
+            )
+            Write-Output "$output_name=$output_value";
+        }
+        Mock toGitHub -MockWith { Write-Output "$output_name=$output_value";}
+    }
+
+    Context "when processing default GitHub environment variables" {
+        It "should output all default GitHub environment variables as --env arguments" {
+            $result = .\assign_default_environment_variables.ps1
+
+            $defaultGitHubEnvVars = @(
+                "CI", "GITHUB_ACTION", "GITHUB_ACTION_PATH", "GITHUB_ACTION_REPOSITORY",
+                "GITHUB_ACTIONS", "GITHUB_ACTOR", "GITHUB_API_URL", "GITHUB_BASE_REF",
+                "GITHUB_ENV", "GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH", "GITHUB_HEAD_REF",
+                "GITHUB_JOB", "GITHUB_OUTPUT", "GITHUB_PATH", "GITHUB_REF", "GITHUB_REF_NAME",
+                "GITHUB_REF_PROTECTED", "GITHUB_REF_TYPE", "GITHUB_REPOSITORY",
+                "GITHUB_REPOSITORY_OWNER", "GITHUB_RETENTION_DAYS", "GITHUB_RUN_ATTEMPT",
+                "GITHUB_RUN_ID", "GITHUB_RUN_NUMBER", "GITHUB_SERVER_URL", "GITHUB_SHA",
+                "GITHUB_STEP_SUMMARY", "GITHUB_WORKFLOW", "GITHUB_WORKSPACE", "RUNNER_ARCH",
+                "RUNNER_DEBUG", "RUNNER_NAME", "RUNNER_OS", "RUNNER_TEMP", "RUNNER_TOOL_CACHE"
+            )
+
+            # Assert: Verify the output contains all default environment variables
+            foreach ($envVar in $defaultGitHubEnvVars) {
+                $result | Should -Match "--env $envVar"
+            }
+
+            # Assert: Verify the output variable is set correctly
+            $result | Should -Match "default_environment_variables=@"
+        }
+    }
+}

--- a/src/assign_default_environment_variables.ps1
+++ b/src/assign_default_environment_variables.ps1
@@ -1,0 +1,20 @@
+$invocationPath = $PSScriptRoot
+$setOutputVariable = Join-Path $invocationPath "set_output_variable.ps1"
+$splitToArgs = Join-Path $invocationPath "split_to_args.ps1"
+$trimArg = Join-Path $invocationPath "trim_arg.ps1"
+
+$defaultGitHubEnvVars = @(
+    "CI", "GITHUB_ACTION", "GITHUB_ACTION_PATH", "GITHUB_ACTION_REPOSITORY",
+    "GITHUB_ACTIONS", "GITHUB_ACTOR", "GITHUB_API_URL", "GITHUB_BASE_REF",
+    "GITHUB_ENV", "GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH", "GITHUB_HEAD_REF",
+    "GITHUB_JOB", "GITHUB_OUTPUT", "GITHUB_PATH", "GITHUB_REF", "GITHUB_REF_NAME",
+    "GITHUB_REF_PROTECTED", "GITHUB_REF_TYPE", "GITHUB_REPOSITORY",
+    "GITHUB_REPOSITORY_OWNER", "GITHUB_RETENTION_DAYS", "GITHUB_RUN_ATTEMPT",
+    "GITHUB_RUN_ID", "GITHUB_RUN_NUMBER", "GITHUB_SERVER_URL", "GITHUB_SHA",
+    "GITHUB_STEP_SUMMARY", "GITHUB_WORKFLOW", "GITHUB_WORKSPACE", "RUNNER_ARCH",
+    "RUNNER_DEBUG", "RUNNER_NAME", "RUNNER_OS", "RUNNER_TEMP", "RUNNER_TOOL_CACHE"
+)
+
+$defaultGitHubEnv = & $splitToArgs -argument_name "--env" -env_arrays $defaultGitHubEnvVars
+$trimmedArgs = & $trimArg -arg $defaultGitHubEnv
+& $setOutputVariable -name "default_environment_variables" -val "@$trimmedArgs"

--- a/test/default_environment.Tests.ps1
+++ b/test/default_environment.Tests.ps1
@@ -1,0 +1,7 @@
+Describe "default environment" {
+    Context "default environment should always be set" {
+        It "CI should be true" {
+            Write-Output $env:CI | Should -Be "true"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for passing-through the default GitHub defined [environment variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) to the container context