### PR TITLE
chore: add dependabot and pin actions on sha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,7 @@ jobs:
         docker_container: ["mcr.microsoft.com/windows/servercore:ltsc2019"]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Test_Run_Default
         uses: ./
         with:
@@ -103,10 +100,7 @@ jobs:
     container: mcr.microsoft.com/powershell:latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install
         shell: pwsh
         run: >-

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,4 +1,5 @@
 name: Update README
+
 on:
   push:
     branches: [ main ]
@@ -9,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Update README
-        uses: npalm/action-docs-action@v1.2.0
+        uses: npalm/action-docs-action@b1dd20339140224c1ffef389467e4fece8dc416b # v3.1.2
         with:
           readme: ./README.md
           actionFile: ./action.yml
@@ -20,7 +21,7 @@ jobs:
           lineBreaks: LF
 
       - name: commit and push
-        uses: stefanzweifel/git-auto-commit-action@v4.15.0
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           commit_message: "Auto-update README.md"
           branch: "update-readme"
@@ -28,7 +29,7 @@ jobs:
           create_branch: true
 
       - name: Create pull request
-        uses: devops-infra/action-pull-request@master
+        uses: devops-infra/action-pull-request@ff118b4a7c24bac5a3c95acef59e9edd1fc37890 # v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: update-readme


### PR DESCRIPTION
This PR adds Dependabot authority over GitHub Actions.

In the process all actions are updated to the latest version (as of time of the PR) and pinned on their SHAs.