### PR TITLE
chore: mount GitHub Actions _temp path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,12 +93,14 @@ runs:
       shell: powershell
     - name: Run
       run: >-
+        $eventPath = Split-Path -Path "${env:GITHUB_EVENT_PATH}" -Parent;
+
         docker run
         ${{ steps.settings.outputs.default_environment_variables }}
         ${{ steps.settings.outputs.extra_args }}
         --rm
         --memory=${{ inputs.memory }}
-        -v C:\a\_temp\_github_workflow:C:\a\_temp\_github_workflow
+        -v $eventPath:$eventPath
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/action.yml
+++ b/action.yml
@@ -96,8 +96,9 @@ runs:
         docker run
         ${{ steps.settings.outputs.default_environment_variables }}
         ${{ steps.settings.outputs.extra_args }}
-        --rm 
+        --rm
         --memory=${{ inputs.memory }}
+        -v C:\actions-runner\_work\_temp:C:\actions-runner\_work\_temp
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
         ${{ steps.settings.outputs.extra_args }}
         --rm
         --memory=${{ inputs.memory }}
-        -v $eventPath:$eventPath
+        -v ${eventPath}:${eventPath}
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
         ${{ steps.settings.outputs.extra_args }}
         --rm
         --memory=${{ inputs.memory }}
-        -v ${env:GITHUB_EVENT_PATH}:${env:GITHUB_EVENT_PATH}
+        -v $(Split-Path -Path ${env:GITHUB_EVENT_PATH} -Leaf):$(Split-Path -Path ${env:GITHUB_EVENT_PATH} -Leaf)
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
         ${{ steps.settings.outputs.extra_args }}
         --rm
         --memory=${{ inputs.memory }}
-        -v $(Split-Path -Path ${env:GITHUB_EVENT_PATH} -Leaf):$(Split-Path -Path ${env:GITHUB_EVENT_PATH} -Leaf)
+        -v C:\a\_temp\_github_workflow:C:\a\_temp\_github_workflow
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
         ${{ steps.settings.outputs.extra_args }}
         --rm
         --memory=${{ inputs.memory }}
-        -v C:\actions-runner\_work\_temp:C:\actions-runner\_work\_temp
+        -v ${env:GITHUB_EVENT_PATH}:${env:GITHUB_EVENT_PATH}
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/test/run_default.Tests.ps1
+++ b/test/run_default.Tests.ps1
@@ -13,4 +13,10 @@ Describe "run_default" {
             $testfile | Should -Exist
         }
     }
+
+    Context "default GitHub Action paths should be available" {
+        It "GITHUB_EVENT_PATH should exist" {
+            "$env:GITHUB_EVENT_PATH" | Should -Exist
+        }
+    }
 }

--- a/test/run_test.ps1
+++ b/test/run_test.ps1
@@ -8,7 +8,9 @@ if (-not(Test-Path -Path $testPath -PathType Leaf))
     exit 1;
 }
 
-Install-Module -Force Pester
+Install-PackageProvider NuGet -Force;
+If ($? -ne "True" ) { Throw };
+Install-Module -Force Pester;
 If ($? -ne "True" ) { Throw };
 
 $config=New-PesterConfiguration;

--- a/test/run_test.ps1
+++ b/test/run_test.ps1
@@ -14,8 +14,7 @@ powershell.exe -ExecutionPolicy RemoteSigned `Invoke-WebRequest 'https://get.sco
 C:\TMP\install.ps1 -RunAsAdmin;
 scoop install pester;
 
-$config=New-PesterConfiguration;
-$config.Run.Exit=$true;
-$config.Run.Path="$testPath";
+$config = New-PesterConfiguration;
+$config.Run.Path = "$testPath";
 
-Invoke-Pester -Configuration $config;
+Invoke-Pester -CI -Configuration $config;

--- a/test/run_test.ps1
+++ b/test/run_test.ps1
@@ -8,13 +8,15 @@ if (-not(Test-Path -Path $testPath -PathType Leaf))
     exit 1;
 }
 
-# using scoop to install pester
-mkdir C:\TMP;
-powershell.exe -ExecutionPolicy RemoteSigned `Invoke-WebRequest 'https://get.scoop.sh' -outfile C:\TMP\install.ps1;
-C:\TMP\install.ps1 -RunAsAdmin;
-scoop install pester;
+Install-Module -Force Pester
+If ($? -ne "True" ) { Throw };
 
-$config = New-PesterConfiguration;
-$config.Run.Path = "$testPath";
+$config=New-PesterConfiguration;
+If ($? -ne "True" ) { Throw };
+$config.Run.Exit=$true;
+If ($? -ne "True" ) { Throw };
+$config.Run.Path="$testPath";
+If ($? -ne "True" ) { Throw };
 
-Invoke-Pester -CI -Configuration $config;
+Invoke-Pester -Configuration $config;
+If ($? -ne "True" ) { Throw };

--- a/test/run_test.ps1
+++ b/test/run_test.ps1
@@ -10,7 +10,7 @@ if (-not(Test-Path -Path $testPath -PathType Leaf))
 
 Install-PackageProvider NuGet -Force;
 If ($? -ne "True" ) { Throw };
-Install-Module -Force Pester;
+Install-Module -Force -SkipPublisherCheck Pester;
 If ($? -ne "True" ) { Throw };
 
 $config=New-PesterConfiguration;


### PR DESCRIPTION
Tools like SonarQube expect _temp to be present to gather information from the CI system. This is required since we now pass on all GitHub Action environment variables, so we are identified as a GitHub Action runner.