### PR TITLE
Fix errors for current images without D drives.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'fix/**' ]
     paths-ignore:
       - '**.md'
       - '**.MD'
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: Test
     env:
       TEST1: Test1
@@ -26,7 +26,7 @@ jobs:
       TEST_MAPPING_PATH: "C:\\map"
     strategy:
       matrix:
-        docker_container: ["mcr.microsoft.com/windows/servercore:ltsc2019"]
+        docker_container: ["mcr.microsoft.com/windows/servercore:ltsc2022"]
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/action.yml
+++ b/action.yml
@@ -93,14 +93,15 @@ runs:
       shell: powershell
     - name: Run
       run: >-
-        $eventPath = Split-Path -Path "${env:GITHUB_EVENT_PATH}" -Parent;
+        $runnerPathSource = Split-Path -Path "${env:RUNNER_TEMP}" -Parent;
+        $runnerPathTarget = $runnerPathSource.replace('D:', 'C:')
 
         docker run
         ${{ steps.settings.outputs.default_environment_variables }}
         ${{ steps.settings.outputs.extra_args }}
         --rm
         --memory=${{ inputs.memory }}
-        -v ${eventPath}:${eventPath}
+        -v ${runnerPathSource}:${runnerPathTarget}
         -v ${{ steps.settings.outputs.workspace_path }}:${{ steps.settings.outputs.mapping_path }}
         -w ${{ steps.settings.outputs.work_path }}
         ${{ inputs.image }}

--- a/src/parse_input_extra_args.ps1
+++ b/src/parse_input_extra_args.ps1
@@ -16,4 +16,4 @@ $args_env = & "$splitToArgs" -argument_name "@--env" -env_arrays "$envNames";
 $args_entrypoint = & "$setOptionalVariable" -argument_name "@--entrypoint" -setVal "$entryPoint";
 $eargs = & "$trimArg" -arg "$extraArgs";
 $allargs = "@" + "${eargs}" + " " + "${args_env}" + " " + "${args_entrypoint}";
-& "$setoutputVariable" -name extra_args -val "$allargs";
+& "$setoutputVariable" -replace "" -name extra_args -val "$allargs";

--- a/src/parse_input_paths.ps1
+++ b/src/parse_input_paths.ps1
@@ -14,6 +14,6 @@ $work_space_path = & "$getVariable" -defaultVal "$githubWorkSpace" -setVal "$wor
 $mapping_path    = & "$getVariable" -defaultVal "$work_space_path" -setVal "$mappingPath";
 $work_path       = & "$getVariable" -defaultVal "$mapping_path"    -setVal "$workPath";
 
-& "$setoutputVariable" -name workspace_path -val "$work_space_path";
+& "$setoutputVariable" -replace "" -name workspace_path -val "$work_space_path";
 & "$setoutputVariable" -name mapping_path   -val "$mapping_path";
 & "$setoutputVariable" -name work_path      -val "$work_path";

--- a/src/set_output_variable.ps1
+++ b/src/set_output_variable.ps1
@@ -2,7 +2,9 @@
 # set github output with name and value
 param (
     $name,
-    $val = '@'
+    $val = '@',
+    $replace = 'D:',
+    $with = 'C:'
 )
 
 $invovationPath =  "$PSScriptRoot";
@@ -10,12 +12,16 @@ $trimArg        = "$invovationPath" + "\trim_arg.ps1";
 
 $trimmed_name = & $trimArg -arg $name;
 $trimmed_val  = & $trimArg -arg $val;
+if ( $replace -ne "" ) {
+    $trimmed_val  = $trimmed_val.Replace( $replace, $with );
+}
 
 function toGitHub  {
     param(
         $output_name,
         $output_value
     )
+    Write-Output "$output_name=$output_value"
     "$output_name=$output_value" >> $env:GITHUB_OUTPUT;
 }
 

--- a/test/run_default.Tests.ps1
+++ b/test/run_default.Tests.ps1
@@ -16,7 +16,7 @@ Describe "run_default" {
 
     Context "default GitHub Action paths should be available" {
         It "GITHUB_EVENT_PATH should exist" {
-            "$env:GITHUB_EVENT_PATH" | Should -Exist
+            "$env:GITHUB_EVENT_PATH".Replace('D:', 'C:') | Should -Exist
         }
     }
 }


### PR DESCRIPTION
Fix errors when trying to run current Windows container images that do not have a D drive available for mapping onto.

Instead of trying to map specific GitHub dirs from D to C, this maps the entirety of the GitHub runner directory (i.e. D:/a) to the C drive. To allow for that all environment variables that refer to the D: drive are rewritten to refer to the C: drive instead.

An additional change in this is to switch to the Windows 2022 OS and container image for testing. As the 2019 OS was removed. There's also a change to allow testing on fix/ branches to allow for forks to create local test branches ahead of creating PRs.