### PR TITLE
Fix CLIXML captures in build logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install
-        shell: pwsh
+        shell: pwsh -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
         run: >-
              Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted;
              Install-Module -Name Pester -Force -SkipPublisherCheck;
@@ -120,17 +120,17 @@ jobs:
              Install-Module -Name PSScriptAnalyzer -Force;
              Import-Module PSScriptAnalyzer -ErrorAction Stop
       - name: Linter src
-        shell: pwsh
+        shell: pwsh -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
         run: >-
              Invoke-ScriptAnalyzer -Path src -EnableExit;
       - name: Linter test
-        shell: pwsh
+        shell: pwsh -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
         run: >-
              Invoke-ScriptAnalyzer -Path test -EnableExit;
       - name: Test-Action-Scripts
-        shell: pwsh
+        shell: pwsh -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
         run: >-
-             cd src;
+             Set-Location src;
              $config=New-PesterConfiguration;
              $config.Run.Exit=$true;
              Invoke-Pester -Configuration $config;

--- a/action.yml
+++ b/action.yml
@@ -74,11 +74,11 @@ runs:
           ${{ github.action_path }}/src/parse_input_paths.ps1 -githubWorkSpace "${{ github.workspace }}" -workspacePath "@${{ inputs.workspace_path }}" -mappingPath "@${{ inputs.mapping_path }}" -workPath "@${{ inputs.work_path }}";
           ${{ github.action_path }}/src/parse_input_extra_args.ps1 -envNames "@${{ inputs.env_names }}" -entryPoint "@${{ inputs.entrypoint }}" -extraArgs "@${{ inputs.extra_args }}";
           ${{ github.action_path }}/src/assign_default_environment_variables.ps1;
-      shell: powershell
+      shell: powershell -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
     - name: docker_login
       id: docker_login
       if: inputs.registry_authentication == 'true'
-      shell: powershell
+      shell: powershell -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
       run: >-
         docker login ${{ inputs.registry_repository }} -u ${{ inputs.registry_username }} -p ${{ inputs.registry_token }}
     - name: Pre-warm
@@ -90,7 +90,7 @@ runs:
         -w ${{ steps.settings.outputs.work_path }} `
         ${{ inputs.image }} { ${{ inputs.pre-warm-cmd }} }
         exit 0
-      shell: powershell
+      shell: powershell -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
     - name: Run
       run: >-
         $runnerPathSource = Split-Path -Path "${env:RUNNER_TEMP}" -Parent;
@@ -108,10 +108,10 @@ runs:
         {
         ${{ inputs.run }}
         }
-      shell: powershell
+      shell: powershell -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
     - name: docker_logout
       id: docker_logout
       if: inputs.registry_authentication == 'true'
-      shell: powershell
+      shell: powershell -NoLogo -NonInteractive -NoProfile -OutputFormat Text -Command ". '{0}'"
       run: >-
         docker logout ${{ inputs.registry_repository }}


### PR DESCRIPTION
This PR is an attempt to fix issue [CLIXML captures in build logs](https://github.com/philips-software/run-windows-docker-container-action/issues/19).

It adds options to `powershell` and `pwsh` invocations.